### PR TITLE
Add model reuse logic in ZmqOnnxClient

### DIFF
--- a/detector/zmq_onnx_client.py
+++ b/detector/zmq_onnx_client.py
@@ -516,7 +516,11 @@ class ZmqOnnxClient:
         if self._check_model_exists(model_name):
             logger.info(f"Model {model_name} exists locally")
 
-            if self.current_model == model_name and self.session is not None and self.model_ready:
+            if (
+                self.current_model == model_name
+                and self.session is not None
+                and self.model_ready
+            ):
                 logger.info(f"Model {model_name} already loaded, reusing session")
                 response_header = {
                     "model_available": True,

--- a/detector/zmq_onnx_client.py
+++ b/detector/zmq_onnx_client.py
@@ -515,7 +515,17 @@ class ZmqOnnxClient:
 
         if self._check_model_exists(model_name):
             logger.info(f"Model {model_name} exists locally")
-            # Try to load the model
+
+            if self.current_model == model_name and self.session is not None and self.model_ready:
+                logger.info(f"Model {model_name} already loaded, reusing session")
+                response_header = {
+                    "model_available": True,
+                    "model_loaded": True,
+                    "model_name": model_name,
+                    "message": f"Model {model_name} already loaded",
+                }
+                return [json.dumps(response_header).encode("utf-8")]
+
             if self._load_model(model_name):
                 response_header = {
                     "model_available": True,


### PR DESCRIPTION
Fix repeated model reload on every availability request

## Proposed change

`ZmqOnnxClient._handle_model_request` was reloading the ONNX model on every availability request sent by Frigate, even when the same model was already loaded and the session was active. This caused unnecessary CoreML compilation overhead and repeated log spam on every request cycle.

The fix adds a guard at the top of `_handle_model_request` that checks whether the requested model is already loaded (`self.current_model == model_name` and `self.session is not None` and `self.model_ready`). If so, it returns a successful response immediately, reusing the existing `InferenceSession` without reloading.

## Type of change
- [x] Bugfix (non-breaking change which fixes an issue)

## Additional information
- This PR fixes or closes issue: fixes #
- This PR is related to issue:

## Checklist
- [x] The code change is tested and works locally.
- [x] There is no commented out code in this PR.
- [x] The code has been formatted using Ruff (`ruff format detector`)